### PR TITLE
Using old pointer after reallocating new buffer

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -2936,6 +2936,7 @@ CK_RV p11prov_obj_set_ec_encoded_public_key(P11PROV_OBJ *key,
                           "Failed to store key public key");
             return CKR_HOST_MEMORY;
         }
+	key->attrs = ptr;
     }
 
     if (!pub) {


### PR DESCRIPTION
Below issue is reported while running TLS1.3:-

`p11prov_DeriveKey:Host out of memory`

Issue occurs because we are trying to use deallocated memory pointer after reallocating new memory due to which key->attrs get corrupted and finally cause issue in importing correct peer key.